### PR TITLE
Fix dark models - reset brightness nullValue to '1.0'.

### DIFF
--- a/m3export.py
+++ b/m3export.py
@@ -1861,6 +1861,9 @@ class Exporter:
         m3Layer =  self.createInstanceOf("LAYR")
         transferer = BlenderToM3DataTransferer(exporter=self, m3Object=m3Layer, blenderObject=layer, animPathPrefix=animPathPrefix, rootObject=self.scene)
         shared.transferMaterialLayer(transferer)
+        m3Layer.brightness.nullValue = 1.0
+        m3Layer.brightMult.nullValue = 1.0
+        m3Layer.unknowna44bf452.nullValue = 1.0
         m3Layer.fresnelMaxOffset = layer.fresnelMax - layer.fresnelMin
         if m3Layer.structureDescription.structureVersion >= 25:
             m3Layer.fresnelInvertedMaskX = 1.0 - layer.fresnelMaskX


### PR DESCRIPTION
In SC2 3.0 all models exported by m3addon appeared to be broken, as they cause other ingame models to turn dark.

Explained in detail on sc2mapster: http://www.sc2mapster.com/forums/general/general-chat/84155-other-units-doodads-turn-black-when-using-some-custom/

Simply setting nullValue of brightness fields to 1.0 seems to have fix it, as **Cacho56** [found out](http://www.sc2mapster.com/forums/general/general-chat/84155-other-units-doodads-turn-black-when-using-some-custom/?post=11).