### PR TITLE
Add structure for *VertexFormat0x4182007d*

### DIFF
--- a/structures.xml
+++ b/structures.xml
@@ -810,6 +810,30 @@
             <field name="unused" type="fixed8" default-value="1.0" />
         </fields>
     </structure>
+
+    <structure name="VertexFormat0x4182007d">
+        <description>Vertex with two UV coordinates</description>
+        <versions>
+            <version number="0" size="36" />
+        </versions>
+        <fields>
+            <field name="position" type="VEC3V0" />
+            <field name="boneWeight0" type="uint8" default-value="0" />
+            <field name="boneWeight1" type="uint8" default-value="0" />
+            <field name="boneWeight2" type="uint8" default-value="0" />
+            <field name="boneWeight3" type="uint8" default-value="0" />
+            <field name="boneLookupIndex0" type="uint8" default-value="0" />
+            <field name="boneLookupIndex1" type="uint8" default-value="0" />
+            <field name="boneLookupIndex2" type="uint8" default-value="0" />
+            <field name="boneLookupIndex3" type="uint8" default-value="0" />
+            <field name="normal" type="Vector3As3Fixed8V0" />
+            <field name="sign" type="fixed8" />
+            <field name="uv0" type="Vector2As2int16V0" />
+            <field name="uv1" type="Vector2As2int16V0" />
+            <field name="tangent" type="Vector3As3Fixed8V0" />
+            <field name="unused" type="fixed8" default-value="1.0" />
+        </fields>
+    </structure>
     
     <structure name="EVNT">
         <description>An animation sequence event</description>


### PR DESCRIPTION
Based on: *VertexFormat0x186007d*. Has one additional flag 0x40000000 of unkown meaning.
Example of this is *SpaceDockEngineSmall.m3* from SC2.
Can now be imported and exported back, without loss of anything apparent.
  